### PR TITLE
Bump version to 0.2.4.freeagent.1

### DIFF
--- a/lib/authoreyes/version.rb
+++ b/lib/authoreyes/version.rb
@@ -1,3 +1,3 @@
 module Authoreyes
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.2.4.freeagent.1'.freeze
 end


### PR DESCRIPTION
This is a rubygem fork, so use freeagent prerelease tag to track our versions and allow release to GH packages.